### PR TITLE
feat (config): use config port in broker url

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ class mqtt_instance extends instance_skel {
 				id: 'protocol',
 				label: 'Protocol',
 				width: 4,
-				default: 1,
+				default: 'mqtt://',
 				choices: [
 					{ id: 'mqtt://', label: 'mqtt://' },
 					{ id: 'mqtts://', label: 'mqtts://' },
@@ -311,7 +311,10 @@ class mqtt_instance extends instance_skel {
 	}
 
 	_initMqtt() {
-		this.mqttClient = mqtt.connect(this.config.protocol + this.config.broker_ip, {
+		const brokerPort = Number.isNaN(Number.parseInt(this.config.port)) ? '' : `:${this.config.port}`
+		const brokerUrl = `${this.config.protocol}${this.config.broker_ip}${brokerPort}`
+
+		this.mqttClient = mqtt.connect(brokerUrl, {
 			username: this.config.user,
 			password: this.config.password,
 		})


### PR DESCRIPTION
There's an existing option to specify a port number for the
broker connection that is currently not in use. This update
enables the use of that port number by adding it to the
broker URL if a port number is specified.

Resolves #5

Signed-off-by: Johnny Estilles <johnny@estilles.com>