### PR TITLE
Fix resubscription

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export default class GenericMqttInstance extends InstanceBase {
 
 	_resubscribeToTopics() {
 		// Unsubscribe from everything
-		for (const topic of this.mqtt_topic_subscriptions.values()) {
+		for (const topic of this.mqtt_topic_subscriptions.keys()) {
 			try {
 				this.mqttClient.unsubscribe(topic, (err) => {
 					if (!err) {


### PR DESCRIPTION
`mqtt_topic_subscription` is a Map of topics (keys) to a list of subscribers (values). During resubscription to the topics it was iterated over values instead of keys.